### PR TITLE
Youtubeのメタデータ取得用のAPI

### DIFF
--- a/backend/apis/api_components/youtube_search.py
+++ b/backend/apis/api_components/youtube_search.py
@@ -39,8 +39,13 @@ class YouTube_Search_Instance:
         # matching videos, channels, and playlists.
         for search_result in search_response.get("items", []):
             if search_result["id"]["kind"] == "youtube#video":
-                videos.append("title: %s, videoUrl: https://www.youtube.com/watch?v=%s thumbnailsUrl: %s" 
-                        % (search_result["snippet"]["title"], search_result["id"]["videoId"], search_result["snippet"]["thumbnails"]["high"]["url"]))
+                data = dict()
+                data["videoId"] = search_result["id"]["videoId"]
+                data["publishedAt"] = search_result["snippet"]["publishedAt"]
+                data["title"] = search_result["snippet"]["title"]
+                data["videoUrl"] = "https://www.youtube.com/watch?v=" + search_result["id"]["videoId"]
+                data["thumbnailsUrl"] = search_result["snippet"]["thumbnails"]["high"]["url"]
+                videos.append(data)
 
         #print("Videos:\n", "\n".join(videos), "\n")
         return videos

--- a/backend/apis/api_components/youtube_search.py
+++ b/backend/apis/api_components/youtube_search.py
@@ -50,6 +50,26 @@ class YouTube_Search_Instance:
         #print("Videos:\n", "\n".join(videos), "\n")
         return videos
 
+    def get_meta_data(self, videoIDs): # カンマ区切り文字列 videoIDsの例 vOczUoQigww,q4DKmdlUb6I,v0M0Kd5w_fY
+        youtube = build(self.YOUTUBE_API_SERVICE_NAME, self.YOUTUBE_API_VERSION,
+            developerKey=self.DEVELOPER_KEY)
+
+        search_response = youtube.videos().list(
+                part="id,statistics,status",
+                id=videoIDs
+        ).execute()
+
+        items = search_response.get("items", [])
+        meta_data = []
+
+        for item in items:
+            data = dict()
+            data["videoId"] = item["id"]
+            data["statistics"] = item["statistics"]
+            meta_data.append(data)
+
+        return meta_data
+
     if __name__ == "__main__":
         argparser.add_argument("--q", help="Search term", default="Google")
         argparser.add_argument("--max-results", help="Max results", default=25)

--- a/backend/apis/youtube.py
+++ b/backend/apis/youtube.py
@@ -32,6 +32,12 @@ def get_youtube_data(q: str, maxResults: int, db: Session = Depends(get_db)):
     res = YouTube_Search_Instance(read_youtube_key(db)).youtube_search(q, maxResults)
     return res, 200
 
+# 再生回数などのメタデータ取得
+@router.get("/get_youtube_meta_data/")
+def get_youtube_meta_data(videoIDs: str, db: Session = Depends(get_db)):
+    res = YouTube_Search_Instance(read_youtube_key(db)).get_meta_data(videoIDs)
+    return res, 200
+
 #その人のAPIキー一覧
 @router.get("/get_youtube_key_list/")
 def get_youtube_key_list(whose: str, db: Session = Depends(get_db)):


### PR DESCRIPTION
### youtubeの動画の再生回数や投稿日時,高評価数低評価数を返すAPIを作りました。

1. 再生回数, 高評価, 低評価数を返すAPIです。
get_youtube_dataで取得したvideoIDをコンマ区切りにした文字列をクエリに渡します。

![Screen Shot 2021-06-24 at 23 13 11](https://user-images.githubusercontent.com/34850155/123278679-19107980-d542-11eb-9f6a-e78b01b8f27f.png)

2. get_youtube_dataの返り値のフォーマット(投稿日時を含んで)をきれいにしました。

![Screen Shot 2021-06-24 at 23 13 31](https://user-images.githubusercontent.com/34850155/123278718-20378780-d542-11eb-95ba-3a11cb0c760b.png)
