### PR TITLE
Wikipedia Infobox

### DIFF
--- a/backend/apis/api_components/wikipedia_fetch.py
+++ b/backend/apis/api_components/wikipedia_fetch.py
@@ -1,0 +1,35 @@
+import argparse
+import wptools
+
+
+def wikipedia_fetch_prof(q, silent=True):
+    langs = ["ja", "en"]
+    infobox = None
+
+    # 日本人でも日本語版のinfoboxが（なぜか）取れない人がいるので
+    for l in langs:
+        try:
+            so = wptools.page(q, lang=l, silent=silent).get_parse()
+        except LookupError as e:
+            continue
+
+        infobox = so.data["infobox"]
+        if infobox:
+            break
+
+    # infobox が取れなかったらとりあえず LookUpError を投げる
+    if infobox:
+        return infobox
+    else:
+        raise LookupError
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("q")
+    parser.add_argument("--silent", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        print(wikipedia_fetch_prof(args.q, silent=args.silent))
+    except Exception as e:
+        print(e)

--- a/backend/apis/api_components/wikipedia_fetch.py
+++ b/backend/apis/api_components/wikipedia_fetch.py
@@ -10,7 +10,7 @@ def wikipedia_fetch_prof(q, silent=True):
     # 日本人でも日本語版のinfoboxが（なぜか）取れない人がいるので
     for l in langs:
         try:
-            so = wptools.page(q, lang=l, boxterm="", silent=silent).get_parse()
+            so = wptools.page(q, lang=l, boxterm="Infobox", silent=silent).get_parse()
         except LookupError as e:
             continue
 

--- a/backend/apis/wikipedia.py
+++ b/backend/apis/wikipedia.py
@@ -1,15 +1,20 @@
-from fastapi import Depends, APIRouter
+from typing import Optional
+from fastapi import APIRouter, Query
 from apis.api_components.wikipedia_fetch import wikipedia_fetch_prof
 
 router = APIRouter()
 
 
 @router.get("/get_wikipedia_prof/")
-def get_wikipedia_prof(q: str):
+def get_wikipedia_prof(q: str, count: Optional[int] = Query(None, ge=1)):
     try:
         prof = wikipedia_fetch_prof(q)
     except Exception as e:
         # Wikipedia にページ/Infobox がない場合？
         return None, 404
+
+    if count:
+        # python>=3.7
+        prof = dict(list(prof.items())[:count])
 
     return prof, 200

--- a/backend/apis/wikipedia.py
+++ b/backend/apis/wikipedia.py
@@ -1,0 +1,15 @@
+from fastapi import Depends, APIRouter
+from apis.api_components.wikipedia_fetch import wikipedia_fetch_prof
+
+router = APIRouter()
+
+
+@router.get("/get_wikipedia_prof/")
+def get_wikipedia_prof(q: str):
+    try:
+        prof = wikipedia_fetch_prof(q)
+    except Exception as e:
+        # Wikipedia にページ/Infobox がない場合？
+        return None, 404
+
+    return prof, 200

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,7 @@ from apis.oshido import router as oshido_router
 from apis.youtube import router as youtube_router
 from apis.twitter import router as twitter_router
 from apis.news import router as news_router
+from apis.wikipedia import router as wp_router
 
 router = APIRouter()
 router.include_router(
@@ -16,6 +17,9 @@ router.include_router(
 )
 router.include_router(
     news_router,
+)
+router.include_router(
+    wp_router,
 )
 app = FastAPI()
 app.include_router(router)

--- a/docker/backend/requirements.txt
+++ b/docker/backend/requirements.txt
@@ -11,3 +11,4 @@ databases
 oauth2client
 google-api-python-client
 twitter
+wptools


### PR DESCRIPTION
InfoboxをJSON形式で返すエンドポイントを実装しました。
やたらと時間がかかるので叩くタイミングに注意が要る気がします。

~~日本語wikipediaのテンプレートの命名規則がバラバラなせいで作業が増えて怒っています~~

取得できたJSONの例をベタ貼りします↓
query: 大谷翔平
```
[
  {
    "選手名": "大谷翔平",
    "所属球団": "ロサンゼルス・エンゼルス",
    "背番号": "17",
    "選手写真ファイル名": "Shohei Ohtani (48343515351) (cropped).jpg",
    "写真のコメント": "2019年5月27日",
    "国籍": "{{JPN}}",
    "出身地": "[[岩手県]][[水沢市]]（現：[[奥州市]]）",
    "生年月日": "{{生年月日と年齢|1994|7|5}}",
    "身長": "{{フィートとcm (身長用変換)|6|4}}",
    "体重": "{{ポンドとkg (体重用変換)|210}}",
    "利き腕": "右",
    "打席": "左",
    "守備位置": "[[投手]]、[[指名打者]]、[[外野手]]",
    "プロ入り年度": "{{NPBドラフト|2012}}",
    "ドラフト順位": "ドラフト1位",
    "初出場": "NPB / 2013年3月29日<br />MLB / 2018年3月29日",
    "年俸": "$3,000,000（2021年）",
    "経歴": "* [[花巻東高等学校]]\n* [[北海道日本ハムファイターズ]] (2013 - 2017)\n* [[ロサンゼルス・エンゼルス (MLB)|ロサンゼルス・エンゼルス]] (2018 - )",
    "代表チーム": "{{Flagicon|JPN}} [[野球日本代表|日本]]",
    "プレミア12": "[[2015 WBSCプレミア12|2015年]]"
  },
  200
]

```
query: 春日俊彰
```
[
  {
    "名前": "{{ruby|春日|かすが}} {{ruby|俊彰|としあき}}",
    "本名": "春日 俊彰",
    "ニックネーム": "カスミン<br>ダディガ<br>モアイ<br>としちゃんまんじゅうおまんじゅう",
    "生年月日": "{{生年月日と年齢|1979|2|9}}",
    "出身地": "{{JPN}} [[埼玉県]][[所沢市]]",
    "方言": "[[ 埼玉弁]]、[[春日俊彰#春日語| 春日語]]、[[共通語]]",
    "血液型": "[[ABO式血液型|B型]]",
    "身長": "176 [[センチメートル|cm]]",
    "最終学歴": "[[日本大学]][[日本大学商学部・大学院商学研究科|商学部]][[経営学部|経営学科]][[卒業]]",
    "コンビ名": "[[オードリー (お笑いコンビ)|オードリー]]<br/>（旧コンビ名：「ナイスミドル」）",
    "相方": "[[若林正恭]]",
    "芸風": "[[漫才]] [[ボケ]] ※ナイスミドル時代はツッコミ",
    "立ち位置": "右",
    "事務所": "[[ケイダッシュステージ]]",
    "活動時期": "2000年 -",
    "同期": "[[キングコング (お笑いコンビ)|キングコング]]<br>[[スーパーマラドーナ]]<br>[[タイムマシーン3号]]<br>[[ダイアン]]<br>[[ナイツ (お笑いコンビ)|ナイツ]]<br>[[NON STYLE]]<br />[[ハマカーン]]<br />[[ピース (お笑い)|ピース]]<br />[[平成ノブシコブシ]]<br />[[U字工事]]<br>[[なかやまきんに君]]<br>[[アンガールズ]]<br>など",
    "過去の代表番組": "[[学生才能発掘バラエティ 学生HEROES!]]<br />[[オードリー春日のカスカスTV]]<br>[[東京ディズニーリゾート My マップ!]]<br>[[ネプ&イモトの世界番付]]<br>[[ポケモンゲット☆TV]]<br />[[オードリー春日の知っとく!ベジライフ]]<br />[[むっつり春日]]<br>[[スマイルすきっぷ〜明日の元気をフルチャージ!〜]]<br>[[犬も食わない]]（YouTubeスピンオフ古井ひでおチャンネル）<br>など",
    "他の活動": "[[埼玉県]][[所沢市]][[観光大使]]",
    "配偶者": "一般人女性（2019年 - ）",
    "公式サイト": "[https://plaza.rakuten.co.jp/tonyboyjr/ 公式ブログ]",
    "受賞歴": "（個人賞のみ記載）\n* 2006年\n** 8月 : [[Qさま!!]] 第2回芸能界潜水No.1決定戦公式記録大会 110m - 当時日本歴代2位\n** 12月 : Qさま!! Dynamic Apnea without Fin Japan‐Italy joint competition 115m - 当時日本歴代4位タイ\n* 2009年 : \"トゥース!\"が[[新語・流行語大賞]]にノミネート\n* 2015年 : 第23回東京オープン[[ボディビル]]選手権大会 75kg級 - 5位入賞\n* 2015年 : [[フィンスイミング]]ワールドカップマスターズ大会 日本代表 - 銅メダル\n* 2015年 : 第28弾 [[人志松本のすべらない話]] - MVS受賞\n* 2016年 : [[フィンスイミング]]ワールドカップマスターズ大会 日本代表 - 銀メダル\n* 2016年 : [[全日本社会人レスリング選手権大会]] マスターズAクラス76kg級 - 4位入賞\n* 2017年 : 第29回全日本[[エアロビクス]]コンテスト大会 男子シングル部門 - 3位入賞\n* 2017年 : [[HITOSHI MATSUMOTO presents ドキュメンタル]] シーズン3 第3話・最終話 MWP受賞\n* 2018年 : ウィジードッグクラブ関東[[ドッグスポーツ#ドッグスポーツのリスト|ドッグダンス]]競技会 マスタークラス - 4位入賞\n* 2019年 : [[笑いが無理なら体張れ]] - 完全制覇\n* 2021年 : 全日本エアロビクスコンテスト大会 一般ペア・グループ部門 - [[フワちゃん]]と組んで銅メダル"
  },
  200
]
```

query: 新垣結衣
```
[
  {
    "芸名": "新垣 結衣",
    "ふりがな": "あらがき ゆい",
    "出生地": "{{JPN}} ・[[沖縄県]][[那覇市]]",
    "身長": "169&nbsp;[[センチメートル|cm]] {{refn|group|=|\"注\"|レプロエンタテインメント公式プロフィールによる|ref| name=\"off\" |。}} 。",
    "血液型": "[[ABO式血液型|A型]]",
    "生年": "1988",
    "生月": "6",
    "生日": "11",
    "職業": "[[俳優|女優]]、[[歌手]]、[[ファッションモデル]]",
    "ジャンル": "[[テレビドラマ]]、[[映画]]、[[コマーシャルメッセージ|CM]]",
    "活動期間": "[[2001年]] -",
    "事務所": "フリー（一部[[レプロエンタテインメント]]と契約）",
    "公式サイト": "[https://www.lespros.co.jp/artists/yui-aragaki/ プロフィール]",
    "公式ファンクラブ": "[http://yui-aragaki.lespros.co.jp/ 新垣結衣オフィシャルファンクラブ]",
    "主な作品": "'''テレビドラマ'''<br />『[[Sh15uya]]』<br />『[[ドラゴン桜 (テレビドラマ)|ドラゴン桜]]』<br/>『[[ギャルサー (テレビドラマ)|ギャルサー]]』<br />『[[マイ☆ボス マイ☆ヒーロー]]』<br />『[[パパとムスメの7日間]]』<br />『[[コード・ブルー -ドクターヘリ緊急救命-]]』シリーズ<br />『[[スマイル (テレビドラマ)|スマイル]]』<br/>『[[全開ガール]]』<br />『[[リーガル・ハイ]]』シリーズ<br/>『[[空飛ぶ広報室#テレビドラマ|空飛ぶ広報室]]』<br  />『[[忘却探偵シリーズ#テレビドラマ|掟上今日子の備忘録]]』<br />『[[逃げるは恥だが役に立つ#テレビドラマ|逃げるは恥だが役に立つ]]』<br />『[[獣になれない私たち]]』<hr />'''映画'''<br />『[[恋するマドリ]]』<br />『[[恋空]]』<br />『[[BALLAD 名もなき恋のうた]]』<br />『[[ハナミズキ (映画)|ハナミズキ]]』<br />『[[麒麟の翼#映画|麒麟の翼 〜劇場版・新参者〜]]』<br />『[[トワイライト ささらさや]]』<br />『[[くちびるに歌を]]』<br />『[[ミックス。]]』<br />『[[コード・ブルー -ドクターヘリ緊急救命-]]』<hr />\n'''音楽'''<br />『[[そら (新垣結衣のアルバム)|そら]]』<br />『[[Make my day (新垣結衣の曲)|Make my day]]』",
    "ブルーリボン賞": "'''主演女優賞'''<br/>[[ブルーリボン賞 (映画)#第60回（2017年度）|2017年]]『ミックス。』<br/>'''新人賞'''<br/>[[ブルーリボン賞 (映画)#第50回（2007年度）|2007年]]『[[恋するマドリ]]』<br />『[[ワルボロ#映画|ワルボロ]]』<br />『恋空』",
    "日本アカデミー賞": "'''優秀主演女優賞'''<br/>[[第41回日本アカデミー賞|2017年]]『[[ミックス。]]』<br/> '''新人俳優賞''' <br/>[[第31回日本アカデミー賞|2007年]]『[[恋空#映画|恋空]]』",
    "その他の賞": "[[#受賞歴|受賞歴]]参照"
  },
  200
]
```

query: 丹羽孝希
```
[
  {
    "所属チーム": "スヴェンソンホールディングス",
    "チームカラー": "#E60039",
    "五輪メダル": "[[ファイル:Silver medal olympic.svg|20px|aink=]]",
    "氏名": "丹羽 孝希",
    "画像": "丹羽孝希 打球.jpg",
    "よみがな": "にわ こうき",
    "ラテン文字": "NIWA Koki",
    "愛称": "コキニワ",
    "生年月日": "{{生年月日と年齢|1994|10|10}}",
    "国籍": "{{JPN}}",
    "出身地": "{{flagicon|北海道}} [[北海道]][[苫小牧市]]",
    "性別": "男性",
    "血液型": "[[ABO式血液型|O型]]",
    "身長": "162",
    "体重": "51",
    "公式サイト": "https://t-4.jp/management/koki-niwa",
    "最高世界ランク": "5",
    "最高ランク日付": "2017年11月",
    "現在世界ランク": "17",
    "段級位": "7",
    "利き腕": "左",
    "グリップ": "シェークハンド",
    "ラケット": "KOKI NIWA WOOD",
    "フォア面ラバー": "VICTAS V>15エキストラ",
    "バック面ラバー": "VICTAS トリプルダブルエキストラ",
    "戦型": "左シェーク[[卓球#裏ソフトラバー|裏]]裏[[ドライブ主戦型|ドライブ型]]",
    "ITTFサイト": "[https://results.ittf.link/index.php?option=com_fabrik&view=details&formid=99&Itemid=266&rowid=110729&resetfilters=1 ITTFプロフィール]",
    "学歴": "[[明治大学]]",
    "所属": "* [[琉球アスティーダ]]\n*[[スヴェンソン]]\n* [[木下マイスター東京]]\n* [[岡山リベッツ]]\n* [[スヴェンソンホールディングス]]/[[T.T彩たま]]",
    "代表歴": "{{flagicon|JPN}} [[卓球日本代表|日本代表]] 2009-2019",
    "デビュー年": "2006",
    "通算試合": "657",
    "通算勝利": "441",
    "通算勝率": "67",
    "世界選手権出場大会数": "10",
    "世界選手権初出場": "[[第50回世界卓球選手権個人戦|2009]]",
    "世界選手権最終出場": "[[第55回世界卓球選手権個人戦|2019]]",
    "国内戦歴": "* [[全日本卓球選手権大会|全日本選手権]] シングルス 2012\n* [[全日本卓球選手権大会|全日本選手権]] 男子ダブルス 2010,2012,2016\n* [[ジャパントップ12卓球大会|ジャパントップ12]] 2015",
    "受賞歴": "*[[上月スポーツ賞]] 2017",
    "medaltemplates": "{{MedalCountry|JPN}} {{JPN}} {{MedalSport|[[男性|男子]][[卓球]]}} {{MedalCompetition|[[オリンピックの卓球競技|オリンピック]]}} {{MedalSilver|[[2016年リオデジャネイロオリンピック|2016 リオデジャネイロ]]|[[2016年リオデジャネイロオリンピックの卓球競技|男子団体]]}} {{MedalCompetition|[[世界卓球選手権]]}} {{MedalBronze|[[第51回世界卓球選手権団体戦|2012 ドルトムント]]|男子団体}} {{MedalBronze|[[第52回世界卓球選手権団体戦|2014 東京]]|男子団体}} {{MedalBronze|[[第53回世界卓球選手権個人戦|2015 蘇州]]|男子ダブルス}} {{MedalSilver|[[第53回世界卓球選手権団体戦|2016 クアラルンプール]]|男子団体}} {{MedalBronze|[[第54回世界卓球選手権個人戦|2017 デュッセルドルフ]]|男子ダブルス}} {{MedalCompetition|[[ワールドカップ (卓球)|ワールドカップ]]}} {{MedalBronze|2011 マクデブルク|男子団体}} {{MedalBronze|2013 広州|男子団体}} {{MedalSilver|2018‥|男子団体}} {{MedalCompetition|[[ITTFワールドツアーグランドファイナル|ワールドツアーグランドファイナル]]}} {{MedalSilver|仮リンク|ワールドツアーグランドファイナル|label|=|2012 杭州|en|List of ITTF World Tour Grand Finals medalists|男子ダブルス}} {{仮リンク|ワールドツアーグランドファイナル|label|=|2012 杭州|en|List of ITTF World Tour Grand Finals medalists}} {{MedalSilver|仮リンク|ワールドツアーグランドファイナル|label|=|2014 バンコク|en|List of ITTF World Tour Grand Finals medalists|男子ダブルス}} {{仮リンク|ワールドツアーグランドファイナル|label|=|2014 バンコク|en|List of ITTF World Tour Grand Finals medalists}} {{MedalCompetition|[[アジア卓球選手権]]}} {{MedalBronze|仮リンク|アジア卓球選手権大会メダリスト一覧|label|=|2009 ラクナウ|en|List of Asian Table Tennis Championships medalists|男子ダブルス}} {{仮リンク|アジア卓球選手権大会メダリスト一覧|label|=|2009 ラクナウ|en|List of Asian Table Tennis Championships medalists}} {{MedalSilver|仮リンク|アジア卓球選手権大会メダリスト一覧|label|=|2009 ラクナウ|en|List of Asian Table Tennis Championships medalists|男子団体}} {{仮リンク|アジア卓球選手権大会メダリスト一覧|label|=|2009 ラクナウ|en|List of Asian Table Tennis Championships medalists}} {{MedalSilver|仮リンク|アジア卓球選手権大会メダリスト一覧|label|=|2012 マカオ|en|List of Asian Table Tennis Championships medalists|男子団体}} {{仮リンク|アジア卓球選手権大会メダリスト一覧|label|=|2012 マカオ|en|List of Asian Table Tennis Championships medalists}} {{MedalSilver|仮リンク|アジア卓球選手権大会メダリスト一覧|label|=|2013 釜山|en|List of Asian Table Tennis Championships medalists|混合ダブルス}} {{仮リンク|アジア卓球選手権大会メダリスト一覧|label|=|2013 釜山|en|List of Asian Table Tennis Championships medalists}} {{MedalSilver|仮リンク|アジア卓球選手権大会メダリスト一覧|label|=|2013 釜山|en|List of Asian Table Tennis Championships medalists|男子団体}} {{仮リンク|アジア卓球選手権大会メダリスト一覧|label|=|2013 釜山|en|List of Asian Table Tennis Championships medalists}} {{MedalBronze|仮リンク|アジア卓球選手権大会メダリスト一覧|label|=|2013 釜山|en|List of Asian Table Tennis Championships medalists|男子ダブルス}} {{仮リンク|アジア卓球選手権大会メダリスト一覧|label|=|2013 釜山|en|List of Asian Table Tennis Championships medalists}} {{MedalSilver|2015 パタヤ|男子団体}} {{MedalBronze|2015 パタヤ|男子ダブルス}} {{MedalBronze|[[2017年アジア卓球選手権|2017 無錫]]|男子団体}} {{MedalBronze|[[2017年アジア卓球選手権|2017 無錫]]|男子シングルス}} {{MedalBronze|[[2017年アジア卓球選手権|2017 無錫]]|男子ダブルス}} {{MedalCompetition|[[アジア競技大会卓球競技|アジア大会卓球競技]]}} {{MedalBronze|[[2010年アジア競技大会における卓球競技|2010 広州]]|男子ダブルス}} {{MedalBronze|[[2010年アジア競技大会における卓球競技|2010 広州]]|男子団体}} {{MedalBronze|[[2014年アジア競技大会における卓球競技|2014 仁川]]|男子ダブルス}} {{MedalBronze|[[2014年アジア競技大会における卓球競技|2014 仁川]]|男子団体}} {{MedalCompetition|[[世界ジュニア卓球選手権|世界ジュニア選手権]]}} {{MedalBronze|[[2008年世界ジュニア卓球選手権|2008 マドリード]]|男子ダブルス}} {{MedalBronze|[[2008年世界ジュニア卓球選手権|2008 マドリード]]|男子団体}} {{MedalBronze|[[2009年世界ジュニア卓球選手権|2009 カルタヘナ]]|男子ダブルス}} {{MedalBronze|[[2009年世界ジュニア卓球選手権|2009 カルタヘナ]]|男子団体}} {{MedalGold|[[2010年世界ジュニア卓球選手権|2010 ブラチスラヴァ]]|男子ダブルス}} {{MedalSilver|[[2010年世界ジュニア卓球選手権|2010 ブラチスラヴァ]]|男子団体}} {{MedalGold|[[2011世界ジュニア卓球選手権|2011 マナーマ]]|男子シングルス}} {{MedalBronze|[[2011世界ジュニア卓球選手権|2011 マナーマ]]|男子ダブルス}} {{MedalSilver|[[2011年世界ジュニア卓球選手権|2011 マナーマ]]|男子団体}} {{MedalCompetition|[[アジアジュニア卓球選手権|アジアジュニア選手権]]}} {{MedalBronze|[[2009年アジアジュニア卓球選手権|2009 ジャイプル]]|男子団体}} {{MedalGold|[[2010年アジアジュニア卓球選手権|2010 バンコク]]|男子ダブルス}} {{MedalSilver|[[2010年アジアジュニア卓球選手権|2010 バンコク]]|男子団体}}"
  },
  200
]
```
query: 月ノ美兎
```
[
  {
    "name": "月ノ 美兎",
    "image": "Tsukino Mito.png",
    "birth_date": "[[9月24日]]",
    "occupation": "[[バーチャルYouTuber]]",
    "channel_url": "UCD-miitqNY3nyukJ4Fnf4_A",
    "channel_display_name": "月ノ美兎",
    "years_active": "[[2018年]][[2月4日]] -",
    "genre": "[[生放送]]・[[コメディ]]・[[ゲーム実況]]",
    "subscribers": "70万人",
    "views": "132,924,000回",
    "network": "[[にじさんじ]]",
    "silver_button": "yes",
    "silver_year": "2018",
    "gold_button": "no",
    "stats_update": "2021年2月10日"
  },
  200
]
```
