### PR TITLE
検索窓に別の有名人の名前を入れた時に、強制的に遷移させる

### DIFF
--- a/frontend/src/views/Celebs.vue
+++ b/frontend/src/views/Celebs.vue
@@ -204,6 +204,11 @@ export default {
             return this.oshido
         }
     },
+    watch: {
+      $route() {
+        this.$router.go({path: this.$router.currentRoute.path, force: true});
+      }
+    },
     methods: {
         resetScrollY: function() {
             this.scrollY = 0


### PR DESCRIPTION
検索窓で名前を入れてエンターを押したときに、URLは変わるので
watchってところで強制的にそのURLに遷移するようにしたら、内容が更新されました。

もうちょっといいやり方はあるのかもしれませんが...